### PR TITLE
Specific ignores for Flake8

### DIFF
--- a/python/flake8
+++ b/python/flake8
@@ -1,7 +1,10 @@
 [flake8]
 max-line-length = 88
+ignore =
+    E203  # disables "whitespace before ':'", as this is sometimes desired by PEP8 (and Black manages this)
+    W503  # disabled "line break before binary operator", which is the preferred style
+    W505  # ignored by default (doc line too long (82 > 79 characters))
 exclude =
     .pip,
     docker-compose,
     secrets
-


### PR DESCRIPTION
This alters the default ignores for Flake8 to remove the Black-enforced ones and add a single one where Flake8 and PEP-8 disagree (and where Black generates the output that is considered faulty by Flake8, leading to conflicts when running both `flake8` and `black`.)