### PR TITLE
Updates flake8 config for new major release

### DIFF
--- a/python/flake8
+++ b/python/flake8
@@ -1,9 +1,11 @@
 [flake8]
+# Follows maximum line length from black (80, with 10% room for exceptions)
 max-line-length = 88
-ignore =
-    E203  # disables "whitespace before ':'", as this is sometimes desired by PEP8 (and Black manages this)
-    W503  # disabled "line break before binary operator", which is the preferred style
-    W505  # ignored by default (doc line too long (82 > 79 characters))
+
+# [E203] disables "whitespace before ':'", as this is desired in some slices (and black manages this)
+# [W503] disables "line break before binary operator", preferred style (contrast W504)
+# [W505] disabled "doc line too long" (disabled by default)
+ignore = E203 W503 W505
 exclude =
     .pip,
     __pypackages__,


### PR DESCRIPTION
Reformats comments on ignore as new flake8 6.0 release doesn't like end-of-line comments.