### PR TITLE
Disable flake8 E704 to allow abstract/dummy function defs inline

### DIFF
--- a/python/flake8
+++ b/python/flake8
@@ -5,7 +5,8 @@ max-line-length = 88
 # [E203] disables "whitespace before ':'", as this is desired in some slices (and black manages this)
 # [W503] disables "line break before binary operator", preferred style (contrast W504)
 # [W505] disabled "doc line too long" (disabled by default)
-ignore = E203 W503 W505
+# [E704] disables "Multiple statements on one line (def)", allowing dummy function definitions inline
+ignore = E203 W503 W505 E704
 exclude =
     .pip,
     __pypackages__,


### PR DESCRIPTION
Fixes conflict between black and flake8 
For dummy class and function implementations, black now formats these compactly on one line (e.g `def func(self, x): ...` ), whereas flake8 does not allow multiple statements inline ([E704](https://www.flake8rules.com/rules/E704.html))
Disabling E704