### PR TITLE
Ignore W504: line break after binary operator.

### DIFF
--- a/python/flake8
+++ b/python/flake8
@@ -4,9 +4,10 @@ max-line-length = 88
 
 # [E203] disables "whitespace before ':'", as this is desired in some slices (and black manages this)
 # [W503] disables "line break before binary operator", preferred style (contrast W504)
-# [W505] disabled "doc line too long" (disabled by default)
+# [W504] disables "line break after binary operator", for trailing positional-only indicator in paramspec (black-managed)
+# [W505] disables "doc line too long" (disabled by default)
 # [E704] disables "Multiple statements on one line (def)", allowing dummy function definitions inline
-ignore = E203 W503 W505 E704
+ignore = E203 W503 W504 W505 E704
 exclude =
     .pip,
     __pypackages__,


### PR DESCRIPTION
Resolves flake8 induced style error (due to function signature breaking enforced by black) in bloomon/pylib-fastapi#16