### PR TITLE
[WHT-3226] Add `ruff.toml` for python projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# style-guide
-Code style guidelines and configurations.
+# Style Guide
+
+## Overview
+
+Shared code style configurations and linting rules for Python, Ruby, and TypeScript/JavaScript projects.
+Used as a git submodule across multiple repositories to maintain consistent code formatting and quality standards.
+
+### Tech stack
+
+| Category | Technologies                      |
+| -------- | --------------------------------- |
+| Python   | Ruff, Flake8 (legacy)             |
+| Ruby     | RuboCop                           |
+| TypeScript/JavaScript | Biome                |
+
+## Usage as submodule
+
+### Adding to a project
+
+```sh
+# Add as submodule
+git submodule add git@github.com:bloomon/style-guide style-guide
+
+# Initialize and update
+git submodule update --init --recursive
+```
+
+### Using configurations
+
+**Python (Ruff)**
+```sh
+# In pyproject.toml
+[tool.ruff]
+extend = "style-guide/python/ruff.toml"
+```
+
+**Python (Flake8 - legacy)**
+```sh
+# In setup.cfg or tox.ini
+[flake8]
+extend-config = style-guide/python/flake8
+```
+
+**Ruby (RuboCop)**
+```sh
+# In .rubocop.yml
+inherit_from: style-guide/ruby/rubocop.yml
+```
+
+**TypeScript/JavaScript (Biome)**
+```sh
+# In biome.json
+{
+  "extends": ["./style-guide/typescript/biome.json"]
+}
+```
+
+### Updating submodule
+
+```sh
+# Update to latest version
+git submodule update --remote style-guide
+
+# Commit the update
+git add style-guide
+git commit -m "Update style-guide submodule"
+```

--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -1,0 +1,51 @@
+# Common linting and formatting rules for all Python projects.
+line-length = 88
+indent-width = 4
+show-fixes = true
+unsafe-fixes = false
+extend-exclude = [
+    ".pip",
+    "__pypackages__",
+    "docker-compose",
+    "secrets",
+    ".git",
+    ".venv",
+    "__pycache__",
+]
+src = ["src", "tests"]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+
+[lint]
+select = [
+    "B",   # flake8-bugbear
+    "BLE", # flake8-blind-except
+    "C90", # mccabe
+    "DJ",  # flake8-django
+    "E",   # pycodestyle
+    "ERA", # eradicate
+    "F",   # pyflakes
+    "I",   # isort
+    "PGH", # pygrep-hooks
+    "PIE", # flake8-pie
+    "PT",  # flake8-pytest-style
+    "Q",   # flake8-quotes
+    "T20", # flake8-print
+    "W",   # pycodestyle
+]
+ignore = [
+    "B008",  # no-function-call-in-argument-defaults
+    "B904",  # raise-without-from-inside-except
+    "B905",  # zip-without-explicit-strict
+    "DJ001", # django-nullable-model-string-field
+]
+unfixable = ["B", "ERA", "PIE", "PT"]
+
+[lint.flake8-builtins]
+ignorelist = ["id"]
+
+[lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true


### PR DESCRIPTION
[Jira ticket](https://bloomon.atlassian.net/browse/WHT-3226)

### PR Overview
- Updates `README.md` to follow the format of BMS's readme
- Adds a `ruff.toml` file with a ruff configuration that can be imported in python projects:

```
[tool.ruff]
target-version = "py312"
extend = "style-guide/python/ruff.toml"
```