### PR TITLE
[WHT-3226] Cut `tool.ruff` from definition

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -44,7 +44,7 @@ ignore = [
 ]
 unfixable = ["B", "ERA", "PIE", "PT"]
 
-[tool.ruff.lint.flake8-annotations]
+[lint.flake8-annotations]
 allow-star-arg-any = true
 
 [lint.flake8-builtins]


### PR DESCRIPTION
Fixes the rules added in https://github.com/bloomon/style-guide/pull/11 that were missed from https://github.com/bloomon/style-guide/pull/10