### PR TITLE
[WHT-3226] Add `mccabe` rule to the ignore list

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -41,6 +41,7 @@ ignore = [
     "B904",  # raise-without-from-inside-except
     "B905",  # zip-without-explicit-strict
     "DJ001", # django-nullable-model-string-field
+    "C901",  # McCabe complexity check
 ]
 unfixable = ["B", "ERA", "PIE", "PT"]
 


### PR DESCRIPTION
[Jira ticket](https://bloomon.atlassian.net/browse/WHT-3226)

### PR Overview
- Adds the McCabe rule to the ignore list. Projects can re-enable it by actively selecting the `C901` rule