### PR TITLE
Disable E741 (ambiguous-variable-name) in ruff config

### DIFF
--- a/python/ruff.toml
+++ b/python/ruff.toml
@@ -42,6 +42,7 @@ ignore = [
     "B905",  # zip-without-explicit-strict
     "DJ001", # django-nullable-model-string-field
     "C901",  # McCabe complexity check
+    "E741",  # ambiguous-variable-name
 ]
 unfixable = ["B", "ERA", "PIE", "PT"]
 


### PR DESCRIPTION
This is the reasoning for the [ambiguous-variable-name](https://docs.astral.sh/ruff/rules/ambiguous-variable-name/) linting error:
> In some fonts, these characters are indistinguishable from the numerals one and zero.
> When tempted to use 'l', use 'L' instead.

I think this reasoning doesn't hold in a dev-setup where generally legible fonts are used that clearly distinguish characters from each other.

I hit this error when introducing ruff in [PR](https://github.com/bloomon/pylib-printnode/pull/1) to cleanup our recently forked pylib-printnode repository:
```
E741 Ambiguous variable name: `l`
 --> src/bloomon/printnode/util.py:7:18
  |
5 |     letters = list(text.strip())
6 |     indexes = [
7 |         i for i, l in enumerate(letters) if l.upper() == l and not re.match("_", l)
  |                  ^
8 |     ]
9 |     for i in reversed(indexes):
```